### PR TITLE
Automatically accommodate changing tests in full coverage

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,12 @@
+[general]
+ignore=body-is-missing
+
+[title-max-length]
+line-length=50
+
+[B1]
+# body line length
+line-length=72
+
+[title-match-regex]
+regex=^[A-Z]

--- a/pytest_plt/tests/test_plt.py
+++ b/pytest_plt/tests/test_plt.py
@@ -1,5 +1,8 @@
 """Test the plt fixture."""
 
+import inspect
+import sys
+
 import numpy as np
 
 
@@ -18,3 +21,10 @@ def test_bbox_extra_artists(plt):
     plt.plot(np.linspace(0, 1, 20), np.linspace(0, 2, 20), label="line")
     legend = plt.legend(loc='upper left', bbox_to_anchor=(1., 1.))
     plt.bbox_extra_artists = (legend,)
+
+
+_fns = inspect.getmembers(sys.modules[__name__], inspect.isfunction)
+plot_tests = [_name for _name, _fn in _fns
+              if _name.startswith('test_')
+              and 'plt' in inspect.getfullargspec(_fn).args]
+plot_tests.remove('test_mock_iter')

--- a/pytest_plt/tests/test_pytest.py
+++ b/pytest_plt/tests/test_pytest.py
@@ -32,12 +32,24 @@ def count_total_outcomes(outcomes):
 
 def test_mock():
     mock = Mock()
+
+    # __getitem__ and __call__ should both return another `Mock`
     assert isinstance(mock["item"], Mock)
+    assert isinstance(mock(), Mock)
+
+    # __mul__ with anything should produce 1.0
     assert mock * "Hi" == 1.0
+
+    # __getattr__ with __file__ and __path__ return "/dev/null"
     assert mock.__file__ == "/dev/null"
     assert mock.__file__ == mock.__path__
+
+    # __getattr__ with uppercase first letter returns a type
     assert mock.Type.__module__ == "pytest_plt"
     assert type(mock.Type) is type
+
+    # __getattr__ with lowercase first letter should return a `Mock`
+    assert isinstance(mock.foo, Mock)
 
 
 def test_plt_no_plots(testdir):

--- a/pytest_plt/tests/test_pytest.py
+++ b/pytest_plt/tests/test_pytest.py
@@ -14,6 +14,19 @@ import os
 from pytest_plt import Mock
 
 pytest_plugins = ["pytester"]
+pytest_outcomes = [
+    'passed', 'skipped', 'failed', 'error', 'xfailed', 'xpassed']
+
+
+def count_total_outcomes(outcomes):
+    """Count the total number of outcomes (tests) in an outcome dict.
+
+    The ``outcomes`` dict is obtained from ``RunResult.parseoutcomes()``.
+
+    ``outcomes`` dict can have other values (e.g. "seconds"), so we can't just
+    sum all values in the dict.
+    """
+    return sum(outcomes.get(outcome, 0) for outcome in pytest_outcomes)
 
 
 def test_mock():
@@ -33,7 +46,9 @@ def test_plt_no_plots(testdir):
     file_path.rename("package/tests/test_plt.py")
 
     result = testdir.runpytest()
-    result.assert_outcomes(passed=3)
+    outcomes = result.parseoutcomes()
+    n_tests = count_total_outcomes(outcomes)
+    assert outcomes['passed'] / n_tests == 1.0, "did not pass all tests"
 
     path = str(testdir.tmpdir)
     assert not os.path.exists(os.path.join(path, "plots"))
@@ -46,7 +61,10 @@ def test_plt_plots(testdir):
     file_path.rename("package/tests/test_plt.py")
 
     result = testdir.runpytest("--plots")
-    result.assert_outcomes(passed=3)
+    # import pdb; pdb.set_trace()
+    outcomes = result.parseoutcomes()
+    n_tests = count_total_outcomes(outcomes)
+    assert outcomes['passed'] / n_tests == 1.0, "did not pass all tests"
 
     plotdir = os.path.join(
         str(testdir.tmpdir), "plots", "package", "tests",

--- a/pytest_plt/tests/test_pytest.py
+++ b/pytest_plt/tests/test_pytest.py
@@ -12,6 +12,7 @@ test files can be run manually by passing them to ``pytest``.
 import os
 
 from pytest_plt import Mock
+import pytest_plt.tests.test_plt as test_plt
 
 pytest_plugins = ["pytester"]
 pytest_outcomes = [
@@ -70,10 +71,7 @@ def test_plt_plots(testdir):
         str(testdir.tmpdir), "plots", "package", "tests",
     )
 
-    assert os.path.exists(os.path.join(
-        plotdir, "test_plt.py::test_simple_plot.pdf",
-    ))
-
-    assert os.path.exists(os.path.join(
-        plotdir, "test_plt.py::test_bbox_extra_artists.pdf",
-    ))
+    for test_name in test_plt.plot_tests:
+        assert os.path.exists(os.path.join(
+            plotdir, "test_plt.py::%s.pdf" % test_name,
+        ))


### PR DESCRIPTION
I've drafted a couple of commits to fix the issues with changing tests in `test_plt.py`. Counting the number of tests so that we check that 100% of tests pass is fairly straightforward, and I think that should be uncontroversial.

Actually listing the tests so that we can check for plots is a bit trickier, though. First of all, it requires a bit of inspect magic which is never ideal. Also, my way of finding tests that should produce plots (i.e. functions that begin with `test_` and have `plt` as an argument) is neither perfectly sensitive or specific. Some tests (e.g. those that appear in Test classes) may be missed (though we rarely use Test classes). And some tests use the `plt` fixture but don't actually produce a plot by design, e.g. if they set `saveas = None`.