### PR TITLE
fix: race condition when running tests under pytest-xdist

### DIFF
--- a/pytest_plt/plugin.py
+++ b/pytest_plt/plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import contextlib
 import errno
 import os
 import pickle
@@ -114,7 +115,7 @@ class Recorder:
     def dirname(self, _dirname):
         if _dirname is not None:
             _dirname = os.path.normpath(_dirname)
-            if not os.path.exists(_dirname):
+            with contextlib.suppress(FileExistsError):
                 os.makedirs(_dirname)
         self._dirname = _dirname
 


### PR DESCRIPTION
This (hopefully) fixes a race condition when running pytest with multiple processes (e.g. with `pytest-xdist`) where making the plotdir can fail. 